### PR TITLE
fix code block ending

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -95,11 +95,13 @@ class Generator {
   }
 
   addTextLine(text, relative) {
+    var codeBlock = this.codeBlock;
+
     if (text.startsWith("```")) {
-      this.codeBlock = !this.codeBlock;
+      this.codeBlock = !codeBlock;
     }
 
-    if (this.codeBlock) {
+    if (this.codeBlock || codeBlock) {
       this.addLine(text);
       return;
     }


### PR DESCRIPTION
End of code blocks had indent as text block strings. For example,  the comment:
~~~cpp
/**
 * ## Example
 * ```cpp
 * void fn() {};
 * ```
 */
~~~
trnaslated to:
~~~md
## Example
```cpp
void fn() {};
    ```
~~~
and now it:
~~~md
## Example
```cpp
void fn() {};
```
~~~